### PR TITLE
Add numbered container names to docker rm example for clarity

### DIFF
--- a/2-Long_Lived_Containers/README.md
+++ b/2-Long_Lived_Containers/README.md
@@ -156,7 +156,7 @@ Looks like you're going to have to get rid of your 'hello-world' containers! The
 ---
 >Pro-Tip: save time by running `docker rm` just once. Simply follow the command with all the container names you would like to remove, like so:
 >
->`docker rm <container-name> <container-name> <container-name> <container-name>` 
+>`docker rm <container-name1> <container-name2> <container-name3> <container-name4>` 
 
 ---
 


### PR DESCRIPTION
PR aims to help improve readability of the docker rm example by numbering the container names. This helps make it immediately clear that the names are placeholders for different containers, rather than repeating the same one

Can create confusion for absolute beginners:
`docker rm <container-name> <container-name> <container-name> <container-name>`

Solution:
`docker rm <container-name1> <container-name2> <container-name3> <container-name4>`
